### PR TITLE
refactor(api): return dates with tokens when signing

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -21,5 +21,5 @@ It also uses `Knifecycle` for a drop in dependency injection
 Finally, it deal with promises which are more convenient than the
  original API.
 
-[See in context](./src/jwt.ts#L39-L52)
+[See in context](./src/jwt.ts#L49-L62)
 

--- a/src/__snapshots__/jwt.test.ts.snap
+++ b/src/__snapshots__/jwt.test.ts.snap
@@ -23,7 +23,7 @@ Object {
 }
 `;
 
-exports[`jwt service initializer should fail without algortithns 1`] = `
+exports[`jwt service initializer should fail without algorithms 1`] = `
 Object {
   "errorCode": "E_NO_JWT_ALGORITHMS",
   "errorParams": Array [],
@@ -82,7 +82,12 @@ Object {
   "times": Array [
     Array [],
   ],
-  "token": "eyJhbGciOiJIUzI1NiJ9.eyJ1c2VySWQiOjIsIm9yZ2FuaXNhdGlvbklkIjozLCJpYXQiOjEzOTA2OTQ0MDAsImV4cCI6MTM5MDg2NzIwMCwibmJmIjoxMzkwNjk0NDAwfQ.DdWhIErffR-N-bTSsjr2tDOyinbMtYkL24IZxOVaB_0",
+  "token": Object {
+    "expiresAt": 1390867200000,
+    "issuedAt": 1390694400000,
+    "token": "eyJhbGciOiJIUzI1NiJ9.eyJ1c2VySWQiOjIsIm9yZ2FuaXNhdGlvbklkIjozLCJpYXQiOjEzOTA2OTQ0MDAsImV4cCI6MTM5MDg2NzIwMCwibmJmIjoxMzkwNjk0NDAwfQ.DdWhIErffR-N-bTSsjr2tDOyinbMtYkL24IZxOVaB_0",
+    "validAt": 1390694400000,
+  },
 }
 `;
 

--- a/src/jwt.test.ts
+++ b/src/jwt.test.ts
@@ -34,7 +34,7 @@ describe('jwt service', () => {
       }
     });
 
-    test('should fail without algortithns', async () => {
+    test('should fail without algorithms', async () => {
       try {
         await initJWTService({
           ENV: {


### PR DESCRIPTION
The signature context is required for example when issuing a token via OAuth to provide expiration time.